### PR TITLE
Changed book media download to save downloaded chunks to file

### DIFF
--- a/src/adapters/gateways/book_storage_gateway.cpp
+++ b/src/adapters/gateways/book_storage_gateway.cpp
@@ -21,6 +21,9 @@ BookStorageGateway::BookStorageGateway(IBookStorageAccess* bookStorageAccess) :
 
     // Save downloaded book
     connect(m_bookStorageAccess,
+            &IBookStorageAccess::downloadingBookMediaChunkReady, this,
+            &BookStorageGateway::downloadingBookMediaChunkReady);
+    connect(m_bookStorageAccess,
             &IBookStorageAccess::downloadingBookMediaFinished, this,
             &BookStorageGateway::downloadingBookMediaFinished);
 

--- a/src/adapters/interfaces/persistance/i_book_storage_access.hpp
+++ b/src/adapters/interfaces/persistance/i_book_storage_access.hpp
@@ -36,7 +36,13 @@ public:
 signals:
     void deletingBookFinished(bool success, const QString& reason);
     void updatingBookFinished(bool success, const QString& reason);
-    void downloadingBookMediaFinished(const QByteArray& data, const QUuid& uuid,
+    void downloadingBookMediaChunkReady(const QByteArray& data,
+                                        const bool isChunkLast,
+                                        const QUuid& uuid,
+                                        const QString& format);
+    void downloadingBookMediaFinished(const QByteArray& data,
+                                      const bool isChunkLast,
+                                      const QUuid& uuid,
                                       const QString& format);
     void gettingBooksMetaDataFinished(std::vector<QJsonObject>& metaData);
     void downloadingBookCoverFinished(const QByteArray& data,

--- a/src/application/interfaces/gateways/i_book_storage_gateway.hpp
+++ b/src/application/interfaces/gateways/i_book_storage_gateway.hpp
@@ -41,7 +41,13 @@ signals:
     void updatingBookFinished(bool success, const QString& reason);
     void gettingBooksMetaDataFinished(
         std::vector<domain::entities::Book>& books);
-    void downloadingBookMediaFinished(const QByteArray& data, const QUuid& uuid,
+    void downloadingBookMediaChunkReady(const QByteArray& data,
+                                        const bool isChunkLast,
+                                        const QUuid& uuid,
+                                        const QString& format);
+    void downloadingBookMediaFinished(const QByteArray& data,
+                                      const bool isChunkLast,
+                                      const QUuid& uuid,
                                       const QString& format);
     void downloadingBookCoverFinished(const QByteArray& data,
                                       const QUuid& uuid);

--- a/src/application/utility/book_storage_manager.cpp
+++ b/src/application/utility/book_storage_manager.cpp
@@ -19,8 +19,11 @@ BookStorageManager::BookStorageManager(
 
     // Save downloaded book
     connect(m_bookStorageGateway,
+            &IBookStorageGateway::downloadingBookMediaChunkReady, this,
+            &BookStorageManager::saveDownloadedBookMediaChunkToFile);
+    connect(m_bookStorageGateway,
             &IBookStorageGateway::downloadingBookMediaFinished, this,
-            &BookStorageManager::saveDownloadedBookMediaToFile);
+            &BookStorageManager::saveDownloadedBookMediaChunkToFile);
 
     // Save book cover
     connect(m_bookStorageGateway,
@@ -45,23 +48,44 @@ void BookStorageManager::clearUserData()
     m_downloadedBooksTracker->clearLibraryOwner();
 }
 
-void BookStorageManager::saveDownloadedBookMediaToFile(const QByteArray& data,
-                                                       const QUuid& uuid,
-                                                       const QString& format)
+void BookStorageManager::saveDownloadedBookMediaChunkToFile(const QByteArray& data,
+                                                            const bool isChunkLast,
+                                                            const QUuid& uuid,
+                                                            const QString& format)
 {
     auto destDir = m_downloadedBooksTracker->getLibraryDir();
     QString fileName = uuid.toString(QUuid::WithoutBraces) + "." + format;
     auto destination = QUrl(destDir.filePath(fileName)).path();
 
-    QFile file(destination);
-    if(!file.open(QIODevice::WriteOnly))
+    static QMap<QString, QSharedPointer<QFile>> filesMap;
+    if (isChunkLast)
     {
-        qDebug() << "Could not open new book file!";
+        filesMap.remove(fileName);
+        emit finishedDownloadingBookMedia(uuid, destination);
         return;
     }
 
-    file.write(data);
-    emit finishedDownloadingBookMedia(uuid, destination);
+    QSharedPointer<QFile> file;
+    if(filesMap.contains(fileName))
+    {
+        file = filesMap[fileName];
+    }
+    else
+    {
+        file = QSharedPointer<QFile>(new QFile(destination));
+        filesMap.insert(fileName, file);
+    }
+
+    if (!file->isOpen())
+    {
+      if(!file->open(QIODevice::Append))
+      {
+          qDebug() << "Could not open new book file!";
+          return;
+      }
+    }
+
+    file->write(data);
 }
 
 void BookStorageManager::saveDownloadedCoverToFile(const QByteArray& data,

--- a/src/application/utility/book_storage_manager.hpp
+++ b/src/application/utility/book_storage_manager.hpp
@@ -33,9 +33,10 @@ public:
     void clearUserData() override;
 
 private slots:
-    void saveDownloadedBookMediaToFile(const QByteArray& data,
-                                       const QUuid& uuid,
-                                       const QString& format);
+    void saveDownloadedBookMediaChunkToFile(const QByteArray& data,
+                                            const bool isChunkLast,
+                                            const QUuid& uuid,
+                                            const QString& format);
     void saveDownloadedCoverToFile(const QByteArray& data, const QUuid& uuid);
     void processBookMetadata(std::vector<domain::entities::Book>& books);
 


### PR DESCRIPTION
Improved the downloading performance and the memory footprint by writing book chunks to the underlying file as soon as they are received