### PR TITLE
improve performance of fuzzy matching

### DIFF
--- a/src/adapters/data_models/shortcuts_model/shortcuts_proxy_model.hpp
+++ b/src/adapters/data_models/shortcuts_model/shortcuts_proxy_model.hpp
@@ -3,6 +3,7 @@
 #include <optional>
 #include <vector>
 #include "adapters_export.hpp"
+#include <rapidfuzz/fuzz.hpp>
 
 namespace adapters::data_models
 {
@@ -32,6 +33,7 @@ signals:
     void filterStringUpdated();
 
 private:
+    std::optional<rapidfuzz::fuzz::CachedRatio> m_filterScorer;
     QString m_filterString;
 };
 

--- a/src/application/utility/string_utils.hpp
+++ b/src/application/utility/string_utils.hpp
@@ -5,7 +5,7 @@
 namespace string_utils
 {
 
-inline double fuzzCompare(const QString& lhs, const QString& rhs)
+inline double substringCompare(const QString& lhs, const QString& rhs)
 {
     // If rhs is a sub-string of lhs, return a high ratio
     auto substringPos = lhs.toLower().indexOf(rhs.toLower());
@@ -18,6 +18,15 @@ inline double fuzzCompare(const QString& lhs, const QString& rhs)
 
         return ratio;
     }
+
+    return 0.0;
+}
+
+inline double fuzzCompare(const QString& lhs, const QString& rhs)
+{
+    double ratio = substringCompare(lhs, rhs);
+    if(ratio > 0)
+        return ratio;
 
     return rapidfuzz::fuzz::ratio(rhs.toStdString(), lhs.toStdString());
 }


### PR DESCRIPTION
Looking at https://github.com/maxbachmann/rapidfuzz-cpp/issues/109 I noticed a couple of things that could be improved in the string matching. Note this PR is in a pretty raw state and just intends to show what could be changed.