### PR TITLE
Fixed button text displaying

### DIFF
--- a/src/presentation/settings/accountPage/MAccountPage.qml
+++ b/src/presentation/settings/accountPage/MAccountPage.qml
@@ -405,7 +405,7 @@ MFlickWrapper {
                         backgroundColor: "transparent"
                         opacityOnPressed: 0.7
                         text: qsTr("Logout")
-                        textColor: Style.colorFocusedButtonText
+                        textColor: Style.colorUnfocusedButtonText
                         fontWeight: Font.Bold
                         fontSize: Fonts.size12
 


### PR DESCRIPTION
hello,i found that  the 'log out' button text is not visible on the account page under the settings page when switching to light theme,beacuse its color is same as the background color #FFFFFF. Would it be more appropriate to switch to another color? maybe you will add more color style in the future.