### PR TITLE
LIB-149 Drag & Dropping existing books in doesn't show issue popup

### DIFF
--- a/src/presentation/homePage/MHomePage.qml
+++ b/src/presentation/homePage/MHomePage.qml
@@ -862,14 +862,14 @@ Page {
         // it interrupts the adding and shows a popup. After the popup is closed, the
         // adding is resumed by calling continueAddingBooks().
         function addBooks(container) {
-            internal.booksCurrentlyAdding = container
-            for (var i = container.length - 1; i >= 0; i--) {
-                internal.lastAddedBookPath = container[i]
+            internal.booksCurrentlyAdding = [...container]
+            for (var i = internal.booksCurrentlyAdding.length - 1; i >= 0; i--) {
+                internal.lastAddedBookPath = internal.booksCurrentlyAdding[i]
                 let result = LibraryController.addBook(
                         internal.lastAddedBookPath)
 
                 // Remove the already added book
-                container.splice(i, 1)
+                internal.booksCurrentlyAdding.splice(i, 1)
 
                 if (result === BookOperationStatus.OpeningBookFailed) {
                     unsupportedFilePopup.open()


### PR DESCRIPTION
doing splice() on a dropEvent.urls was crashing since it is a readOnly property, it crashes after adding the book but before opening any popup. Now it copies the URLs to internal.booksCurrentlyAdding so it can be modified