### PR TITLE
feat(i18n): add Japanese (ja) translation (#221)

### DIFF
--- a/src/presentation/CMakeLists.txt
+++ b/src/presentation/CMakeLists.txt
@@ -26,6 +26,7 @@ set(translation_files
     translations/librum_pt.ts
     translations/librum_id.ts
     translations/librum_bn.ts
+    translations/librum_ja.ts
 )
 qt_add_translations(presentation TS_FILES ${translation_files})
 

--- a/src/presentation/translations/librum_ja.ts
+++ b/src/presentation/translations/librum_ja.ts
@@ -1,0 +1,2492 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja_JP" sourcelanguage="en_US">
+<context>
+    <name>MAboutPage</name>
+    <message>
+        <location filename="../settings/MAboutPage.qml" line="34"/>
+        <source>About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAboutPage.qml" line="35"/>
+        <source>About this application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAboutPage.qml" line="61"/>
+        <source>Details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAboutPage.qml" line="70"/>
+        <source>CURRENT VERSION</source>
+        <extracomment>Keep it capitalized</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAboutPage.qml" line="86"/>
+        <source>QT VERSION</source>
+        <extracomment>Keep it capitalized</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAboutPage.qml" line="105"/>
+        <source>Feedback?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAboutPage.qml" line="143"/>
+        <source>Creator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAboutPage.qml" line="152"/>
+        <source>WEBSITE</source>
+        <extracomment>Keep it capitalized</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAboutPage.qml" line="177"/>
+        <source>CONTACT</source>
+        <extracomment>Keep it capitalized</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAboutPage.qml" line="203"/>
+        <source>DISCORD</source>
+        <extracomment>Keep it capitalized</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAboutPage.qml" line="228"/>
+        <source>GITHUB</source>
+        <extracomment>Keep it capitalized</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAboutPage.qml" line="274"/>
+        <source>This App</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAboutPage.qml" line="296"/>
+        <source>Librum is here for everyone who just wants to enjoy a good book.
+We hope you have a great time using it! Feel free to leave us a rating and some feedback.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MAcceptPolicy</name>
+    <message>
+        <location filename="../registerPage/MAcceptPolicy.qml" line="48"/>
+        <source>I accept the</source>
+        <extracomment>Make sure to translate the following words together to make a logical sentence</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../registerPage/MAcceptPolicy.qml" line="50"/>
+        <source>Terms of Service</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../registerPage/MAcceptPolicy.qml" line="51"/>
+        <source>and the</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../registerPage/MAcceptPolicy.qml" line="53"/>
+        <source>Privacy Policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MAccountPage</name>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="68"/>
+        <source>Account</source>
+        <translation>アカウント</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="85"/>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="465"/>
+        <source>Save</source>
+        <translation>保存</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="127"/>
+        <source>Profile</source>
+        <translation>プロフィール</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="138"/>
+        <source>Name</source>
+        <translation>名前</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="153"/>
+        <source>Email</source>
+        <translation>メールアドレス</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="169"/>
+        <source>Tier</source>
+        <translation>プラン</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="232"/>
+        <source>Change password</source>
+        <translation>パスワードを変更</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="248"/>
+        <source>Password</source>
+        <translation>パスワード</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="269"/>
+        <source>Password confirmation</source>
+        <translation>パスワードの確認</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="310"/>
+        <source>Your data</source>
+        <translation>あなたのデータ</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="321"/>
+        <source>Analyse your reading to make better recommendations</source>
+        <translation>より良いおすすめのために読書内容を分析する</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="335"/>
+        <source>Anonymously share information about the books you read to help us improve Librum</source>
+        <translation>Librumの改善のため、読んだ書籍の情報を匿名で共有する</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="349"/>
+        <source>Collect data on crashes so that we can prevent it from happening again</source>
+        <translation>再発を防止するため、クラッシュに関するデータを収集する</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="362"/>
+        <source>Collect data to display in your statistics</source>
+        <translation>統計に表示するためのデータを収集する</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="393"/>
+        <source>Your Account</source>
+        <translation>あなたのアカウント</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="408"/>
+        <source>Logout</source>
+        <translation>ログアウト</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="428"/>
+        <source>Delete Your Account</source>
+        <translation>アカウントを削除</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="463"/>
+        <source>Whoops</source>
+        <translation>おっと</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="464"/>
+        <source>It looks like you forgot to save your changes, are you sure that you dont want to save them?</source>
+        <translation>変更が保存されていないようです。本当に保存せずに終了しますか？</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="466"/>
+        <source>Don&apos;t save</source>
+        <translation>保存しない</translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="503"/>
+        <location filename="../settings/accountPage/MAccountPage.qml" line="506"/>
+        <source>Passwords don&apos;t match!</source>
+        <translation>パスワードが一致しません！</translation>
+    </message>
+</context>
+<context>
+    <name>MAddFolderPopup</name>
+    <message>
+        <location filename="../homePage/folderSidebar/MAddFolderPopup.qml" line="76"/>
+        <source>Edit Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MAddFolderPopup.qml" line="76"/>
+        <source>Create Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MAddFolderPopup.qml" line="103"/>
+        <source>Folder Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MAddFolderPopup.qml" line="198"/>
+        <source>Icon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MAddFolderPopup.qml" line="239"/>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MAddFolderPopup.qml" line="278"/>
+        <source>Description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MAddFolderPopup.qml" line="324"/>
+        <source>Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MAddFolderPopup.qml" line="324"/>
+        <source>Create</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MAddShortcutPopup</name>
+    <message>
+        <location filename="../settings/shortcutsPage/MAddShortcutPopup.qml" line="110"/>
+        <source>Edit Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/shortcutsPage/MAddShortcutPopup.qml" line="127"/>
+        <source>Action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/shortcutsPage/MAddShortcutPopup.qml" line="134"/>
+        <source>None selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/shortcutsPage/MAddShortcutPopup.qml" line="170"/>
+        <source>The shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/shortcutsPage/MAddShortcutPopup.qml" line="170"/>
+        <source>is already used for</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/shortcutsPage/MAddShortcutPopup.qml" line="189"/>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/shortcutsPage/MAddShortcutPopup.qml" line="223"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MAddTagBox</name>
+    <message>
+        <location filename="../homePage/manageTagsPopup/MAddTagBox.qml" line="48"/>
+        <source>Add a tag...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MAddTagBoxPopup</name>
+    <message>
+        <location filename="../homePage/manageTagsPopup/MAddTagBoxPopup.qml" line="98"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/manageTagsPopup/MAddTagBoxPopup.qml" line="110"/>
+        <source>Rename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/manageTagsPopup/MAddTagBoxPopup.qml" line="119"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MAppearancePage</name>
+    <message>
+        <location filename="../settings/MAppearancePage.qml" line="34"/>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAppearancePage.qml" line="35"/>
+        <source>Make your own experience</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAppearancePage.qml" line="51"/>
+        <source>Restore Defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAppearancePage.qml" line="105"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAppearancePage.qml" line="115"/>
+        <source>Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAppearancePage.qml" line="127"/>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAppearancePage.qml" line="129"/>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAppearancePage.qml" line="144"/>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAppearancePage.qml" line="218"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAppearancePage.qml" line="228"/>
+        <source>Page spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAppearancePage.qml" line="255"/>
+        <source>Display book title in titlebar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAppearancePage.qml" line="280"/>
+        <source>Default Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAppearancePage.qml" line="326"/>
+        <source>Highlights</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAppearancePage.qml" line="335"/>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAppearancePage.qml" line="457"/>
+        <source>Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAppearancePage.qml" line="513"/>
+        <source>Reset settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAppearancePage.qml" line="514"/>
+        <source>Resetting your settings is a permanent action, there
+ will be no way to restore them!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAppearancePage.qml" line="515"/>
+        <source>No, Keep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MAppearancePage.qml" line="516"/>
+        <source>Yes, Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MBehaviorPage</name>
+    <message>
+        <location filename="../settings/MBehaviorPage.qml" line="38"/>
+        <source>Behavior</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MBehaviorPage.qml" line="39"/>
+        <source>Change the way Librum works</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MBehaviorPage.qml" line="55"/>
+        <source>Restore Defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MBehaviorPage.qml" line="85"/>
+        <source>Books</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MBehaviorPage.qml" line="95"/>
+        <source>Cursor mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MBehaviorPage.qml" line="107"/>
+        <source>Hidden after delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MBehaviorPage.qml" line="107"/>
+        <source>Always visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MBehaviorPage.qml" line="132"/>
+        <source>Hide cursor after delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MBehaviorPage.qml" line="157"/>
+        <source>ms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MBehaviorPage.qml" line="169"/>
+        <source>Include new lines in copied text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MBehaviorPage.qml" line="181"/>
+        <source>ON</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MBehaviorPage.qml" line="183"/>
+        <source>OFF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MBehaviorPage.qml" line="205"/>
+        <source>Reset settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MBehaviorPage.qml" line="206"/>
+        <source>Resetting your settings is a permanent action, there
+ will be no way to restore them!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MBehaviorPage.qml" line="207"/>
+        <source>No, Keep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MBehaviorPage.qml" line="208"/>
+        <source>Yes, Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MBook</name>
+    <message>
+        <location filename="../homePage/MBook.qml" line="186"/>
+        <location filename="../homePage/MBook.qml" line="201"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBook.qml" line="332"/>
+        <source>Your book has not been uploaded to the cloud.
+Either you are offline, or your storage is full.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MBookDetailsPopup</name>
+    <message>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="71"/>
+        <source>Book details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="174"/>
+        <source>Change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="189"/>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="398"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="249"/>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="237"/>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="272"/>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="430"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="256"/>
+        <source>Authors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="262"/>
+        <source>Pages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="271"/>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="286"/>
+        <source>Document creator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="293"/>
+        <source>Creation date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="301"/>
+        <source>Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="308"/>
+        <source>Document size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="316"/>
+        <source>Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="322"/>
+        <source>Last opened</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="348"/>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="373"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="417"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="420"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="421"/>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="422"/>
+        <location filename="../homePage/MBookDetailsPopup.qml" line="423"/>
+        <source>files</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MBookMultiSelectRightClickPopup</name>
+    <message>
+        <location filename="../homePage/MBookMultiSelectRightClickPopup.qml" line="25"/>
+        <source>Mark as read</source>
+        <extracomment>If this is too long in any language, use &quot;Read&quot; (past form) instead</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookMultiSelectRightClickPopup.qml" line="34"/>
+        <source>Remove books</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookMultiSelectRightClickPopup.qml" line="44"/>
+        <source>Move to Folder</source>
+        <extracomment>If this is too long, use &quot;To Folder&quot; instead</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MBookRightClickPopup</name>
+    <message>
+        <location filename="../homePage/MBookRightClickPopup.qml" line="32"/>
+        <source>Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookRightClickPopup.qml" line="43"/>
+        <source>Read book</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookRightClickPopup.qml" line="52"/>
+        <source>Book details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookRightClickPopup.qml" line="64"/>
+        <source>Save to files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookRightClickPopup.qml" line="92"/>
+        <source>Manage tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookRightClickPopup.qml" line="102"/>
+        <source>Move to Folder</source>
+        <extracomment>If this is too long, use &quot;To Folder&quot; instead</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MBookRightClickPopup.qml" line="111"/>
+        <source>Remove book</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MBookSelector</name>
+    <message>
+        <location filename="../modules/CustomComponents/bookSelector/MBookSelector.qml" line="14"/>
+        <source>Search Books...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MBookmarksSidebar</name>
+    <message>
+        <location filename="../readingPage/MBookmarksSidebar.qml" line="29"/>
+        <source>Bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MBookmarksSidebar.qml" line="54"/>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MBookmarksSidebar.qml" line="137"/>
+        <source>Add Bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MBookmarksSidebar.qml" line="191"/>
+        <source>New Bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MBookmarksSidebar.qml" line="155"/>
+        <source>Follow</source>
+        <extracomment>Context: &quot;Follow&quot; the bookmark (go to its page)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MBookmarksSidebar.qml" line="167"/>
+        <source>Rename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MBookmarksSidebar.qml" line="179"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MChapterSidebar</name>
+    <message>
+        <location filename="../readingPage/MChapterSidebar.qml" line="36"/>
+        <source>Contents</source>
+        <extracomment>Context: Contents of the book, also known as outline</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MChapterSidebar.qml" line="61"/>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MComboBox</name>
+    <message>
+        <location filename="../modules/CustomComponents/comboBox/MComboBox.qml" line="40"/>
+        <source>Any</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MConfirmAccountDeletionPopup</name>
+    <message>
+        <location filename="../modules/CustomComponents/MConfirmAccountDeletionPopup.qml" line="65"/>
+        <source>Confirm Account Deletion</source>
+        <translation>アカウント削除の確認</translation>
+    </message>
+    <message>
+        <location filename="../modules/CustomComponents/MConfirmAccountDeletionPopup.qml" line="79"/>
+        <source>Deleting your account is an irreversible action.&lt;br&gt;Once you delete your account, there is &lt;b&gt;no&lt;/b&gt; going back. Please be certain.</source>
+        <translation>アカウントの削除は取り消すことができません。&lt;br&gt;一度アカウントを削除すると、&lt;b&gt;元に戻すことはできません&lt;/b&gt;。十分にご確認ください。</translation>
+    </message>
+    <message>
+        <location filename="../modules/CustomComponents/MConfirmAccountDeletionPopup.qml" line="91"/>
+        <source>Your Email</source>
+        <translation>あなたのメールアドレス</translation>
+    </message>
+    <message>
+        <location filename="../modules/CustomComponents/MConfirmAccountDeletionPopup.qml" line="93"/>
+        <source>Confirm the deletion by entering your Account&apos;s email.</source>
+        <translation>アカウントのメールアドレスを入力して、削除を確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../modules/CustomComponents/MConfirmAccountDeletionPopup.qml" line="112"/>
+        <source>Cancel</source>
+        <translation>キャンセル</translation>
+    </message>
+    <message>
+        <location filename="../modules/CustomComponents/MConfirmAccountDeletionPopup.qml" line="128"/>
+        <source>Delete</source>
+        <translation>削除</translation>
+    </message>
+    <message>
+        <location filename="../modules/CustomComponents/MConfirmAccountDeletionPopup.qml" line="138"/>
+        <source>Your email is wrong</source>
+        <translation>メールアドレスが正しくありません</translation>
+    </message>
+</context>
+<context>
+    <name>MDeleteFolderPopup</name>
+    <message>
+        <location filename="../homePage/folderSidebar/MDeleteFolderPopup.qml" line="50"/>
+        <source>Delete %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MDeleteFolderPopup.qml" line="80"/>
+        <source>Books inside the folder will not be deleted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MDeleteFolderPopup.qml" line="99"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MDeleteFolderPopup.qml" line="114"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MDescriptionPopup</name>
+    <message>
+        <location filename="../homePage/folderSidebar/MDescriptionPopup.qml" line="48"/>
+        <source>Describe this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MDescriptionPopup.qml" line="102"/>
+        <source>This folder is about...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MDescriptionPopup.qml" line="138"/>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MDictionaryPopup</name>
+    <message>
+        <location filename="../readingPage/MDictionaryPopup.qml" line="101"/>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MDictionaryPopup.qml" line="355"/>
+        <source>No definitions found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MDictionaryPopup.qml" line="363"/>
+        <source>Search online</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MDictionaryPopup.qml" line="395"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MDownloadBookPopup</name>
+    <message>
+        <location filename="../freeBooksPage/MDownloadBookPopup.qml" line="82"/>
+        <source>Download book</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../freeBooksPage/MDownloadBookPopup.qml" line="138"/>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../freeBooksPage/MDownloadBookPopup.qml" line="155"/>
+        <source>Authors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../freeBooksPage/MDownloadBookPopup.qml" line="172"/>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../freeBooksPage/MDownloadBookPopup.qml" line="189"/>
+        <source>Downloads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../freeBooksPage/MDownloadBookPopup.qml" line="207"/>
+        <source>Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../freeBooksPage/MDownloadBookPopup.qml" line="237"/>
+        <source>Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../freeBooksPage/MDownloadBookPopup.qml" line="263"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MDualToggle</name>
+    <message>
+        <location filename="../modules/CustomComponents/MDualToggle.qml" line="15"/>
+        <source>Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modules/CustomComponents/MDualToggle.qml" line="17"/>
+        <source>Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MEmptyScreenContent</name>
+    <message>
+        <location filename="../homePage/MEmptyScreenContent.qml" line="36"/>
+        <source>Quite empty here, what about adding your first book?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MEmptyScreenContent.qml" line="53"/>
+        <source>Add book</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MExplanationPopup</name>
+    <message>
+        <location filename="../readingPage/MExplanationPopup.qml" line="50"/>
+        <source>You have reached your daily limit.</source>
+        <extracomment>Make sure that the words make a valid sentence</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MExplanationPopup.qml" line="52"/>
+        <source>Upgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MExplanationPopup.qml" line="53"/>
+        <source>to continue.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MExplanationPopup.qml" line="58"/>
+        <source>Oops! The text is too long. Please shorten your selection.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MExplanationPopup.qml" line="67"/>
+        <source>Explain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MExplanationPopup.qml" line="71"/>
+        <source>Explain like I&apos;m five</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MExplanationPopup.qml" line="75"/>
+        <source>Summarize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MExplanationPopup.qml" line="79"/>
+        <source>Give more information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MExplanationPopup.qml" line="83"/>
+        <source>Explain visually</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MExplanationPopup.qml" line="113"/>
+        <source>Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MExplanationPopup.qml" line="121"/>
+        <source>None selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MExplanationPopup.qml" line="144"/>
+        <source>Request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MExplanationPopup.qml" line="283"/>
+        <source>Note: AI responses can be inaccurate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MExplanationPopup.qml" line="299"/>
+        <source>Ask</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MExternalReadingOptionsPopup</name>
+    <message>
+        <location filename="../readingPage/externalReadingToolbar/MExternalReadingOptionsPopup.qml" line="118"/>
+        <source>Invert colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/externalReadingToolbar/MExternalReadingOptionsPopup.qml" line="147"/>
+        <source>Sync book</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/externalReadingToolbar/MExternalReadingOptionsPopup.qml" line="165"/>
+        <source>More options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/externalReadingToolbar/MExternalReadingOptionsPopup.qml" line="186"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MExternalReadingToolBar</name>
+    <message>
+        <location filename="../readingPage/externalReadingToolbar/MExternalReadingToolBar.qml" line="14"/>
+        <source>Unknown name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/externalReadingToolbar/MExternalReadingToolBar.qml" line="168"/>
+        <source>of</source>
+        <extracomment>As in 21 &quot;of&quot; 400</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MExtractPagesPopup</name>
+    <message>
+        <location filename="../toolsPage/MExtractPagesPopup.qml" line="40"/>
+        <source>Extraction succeeded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MExtractPagesPopup.qml" line="41"/>
+        <source>The new book was added to your library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MExtractPagesPopup.qml" line="43"/>
+        <source>Extraction failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MExtractPagesPopup.qml" line="44"/>
+        <source>The extraction failed. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MExtractPagesPopup.qml" line="63"/>
+        <source>Extract Page(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MExtractPagesPopup.qml" line="133"/>
+        <source>Add a comma separated list of page numbers or ranges to extract.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MExtractPagesPopup.qml" line="157"/>
+        <source>Extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MFeedbackPopup</name>
+    <message>
+        <location filename="../modules/CustomComponents/MFeedbackPopup.qml" line="40"/>
+        <source>Got some feedback?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modules/CustomComponents/MFeedbackPopup.qml" line="55"/>
+        <source>Your feedback is crucial for improving Librum. Would you mind sharing your experience by taking a quick survey?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modules/CustomComponents/MFeedbackPopup.qml" line="74"/>
+        <source>No, Thanks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modules/CustomComponents/MFeedbackPopup.qml" line="88"/>
+        <source>Let&apos;s do this!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MFilterByButton</name>
+    <message>
+        <location filename="../homePage/toolbar/filterByButton/MFilterByButton.qml" line="46"/>
+        <source>Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MFilterByPopup</name>
+    <message>
+        <location filename="../homePage/toolbar/filterByButton/MFilterByPopup.qml" line="73"/>
+        <source>e.g. Uncle bob</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/filterByButton/MFilterByPopup.qml" line="76"/>
+        <source>Authors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/filterByButton/MFilterByPopup.qml" line="121"/>
+        <source>Read</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/filterByButton/MFilterByPopup.qml" line="139"/>
+        <source>Unread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/filterByButton/MFilterByPopup.qml" line="160"/>
+        <source>Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/filterByButton/MFilterByPopup.qml" line="100"/>
+        <location filename="../homePage/toolbar/filterByButton/MFilterByPopup.qml" line="161"/>
+        <source>Any</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/filterByButton/MFilterByPopup.qml" line="99"/>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/filterByButton/MFilterByPopup.qml" line="171"/>
+        <source>Pdf</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/filterByButton/MFilterByPopup.qml" line="174"/>
+        <source>Epub</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/filterByButton/MFilterByPopup.qml" line="177"/>
+        <source>Mobi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/filterByButton/MFilterByPopup.qml" line="180"/>
+        <source>Txt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/filterByButton/MFilterByPopup.qml" line="194"/>
+        <source>Only Books</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/filterByButton/MFilterByPopup.qml" line="212"/>
+        <source>Only Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/filterByButton/MFilterByPopup.qml" line="233"/>
+        <source>Apply Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MFolderSidebar</name>
+    <message>
+        <location filename="../homePage/folderSidebar/MFolderSidebar.qml" line="86"/>
+        <source>Organize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MFolderSidebar.qml" line="106"/>
+        <source>All Books</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MFolderSidebar.qml" line="117"/>
+        <source>Unsorted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MFolderSidebar.qml" line="143"/>
+        <source>Folders</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MFolderSidebarItemRigthclickPopup</name>
+    <message>
+        <location filename="../homePage/folderSidebar/MFolderSidebarItemRigthclickPopup.qml" line="76"/>
+        <source>Create subfolder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MFolderSidebarItemRigthclickPopup.qml" line="88"/>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MFolderSidebarItemRigthclickPopup.qml" line="101"/>
+        <source>Move to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MFolderSidebarItemRigthclickPopup.qml" line="123"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MForgotPasswordPage</name>
+    <message>
+        <location filename="../forgotPasswordPage/MForgotPasswordPage.qml" line="75"/>
+        <source>Forgot Password</source>
+        <translation>パスワードをお忘れの場合</translation>
+    </message>
+    <message>
+        <location filename="../forgotPasswordPage/MForgotPasswordPage.qml" line="87"/>
+        <source>Enter your email and we&apos;ll send you a link to reset your password</source>
+        <translation>メールアドレスを入力すると、パスワードを再設定するためのリンクをお送りします。</translation>
+    </message>
+    <message>
+        <location filename="../forgotPasswordPage/MForgotPasswordPage.qml" line="130"/>
+        <source>Send Email</source>
+        <translation>メールを送信</translation>
+    </message>
+    <message>
+        <location filename="../forgotPasswordPage/MForgotPasswordPage.qml" line="147"/>
+        <source>Back to Login</source>
+        <translation>ログインに戻る</translation>
+    </message>
+    <message>
+        <location filename="../forgotPasswordPage/MForgotPasswordPage.qml" line="173"/>
+        <source>Email sent! Keep an eye on your inbox</source>
+        <translation>メールを送信しました。受信トレイをご確認ください。</translation>
+    </message>
+</context>
+<context>
+    <name>MFreeBook</name>
+    <message>
+        <location filename="../freeBooksPage/MFreeBook.qml" line="128"/>
+        <source>.jpeg</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MFreeBooksPage</name>
+    <message>
+        <location filename="../freeBooksPage/MFreeBooksPage.qml" line="22"/>
+        <source>No books were found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../freeBooksPage/MFreeBooksPage.qml" line="28"/>
+        <source>Couldn&apos;t load free books. Please, check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../freeBooksPage/MFreeBooksPage.qml" line="79"/>
+        <source>Free books</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../freeBooksPage/MFreeBooksPage.qml" line="80"/>
+        <source>Choose from over 70,000 books</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MHomePage</name>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="142"/>
+        <source>A new version is available!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="144"/>
+        <source>Update Now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="192"/>
+        <source>Home</source>
+        <extracomment>As in &apos;Home Page&apos;, might be closer to &apos;Start&apos; in other languages</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="196"/>
+        <source>You have %1 books</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="200"/>
+        <source>In Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="202"/>
+        <source>Unsorted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="222"/>
+        <source>Add books</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="516"/>
+        <source>Remove Book?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="517"/>
+        <source>Deleting a book is a permanent action, no one will be
+ able to restore it afterwards!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="518"/>
+        <location filename="../homePage/MHomePage.qml" line="577"/>
+        <source>Remove from Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="519"/>
+        <location filename="../homePage/MHomePage.qml" line="578"/>
+        <source>Delete Everywhere</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="530"/>
+        <location filename="../homePage/MHomePage.qml" line="541"/>
+        <source>Uninstalling failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="530"/>
+        <source>Can&apos;t uninstall book since it is not downloaded.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="538"/>
+        <source>Uninstalling succeeded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="539"/>
+        <source>The book was deleted from your device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="542"/>
+        <location filename="../homePage/MHomePage.qml" line="556"/>
+        <source>Something went wrong.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="552"/>
+        <source>Deleting succeeded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="553"/>
+        <source>The book was successfully deleted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="555"/>
+        <source>Deleting failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="575"/>
+        <source>Remove Books?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="576"/>
+        <source>Deleting books is a permanent action, no one will be
+ able to restore it afterwards!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="625"/>
+        <location filename="../homePage/MHomePage.qml" line="655"/>
+        <source>Remove from Folder?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="626"/>
+        <source>This action will not delete the original book.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="627"/>
+        <location filename="../homePage/MHomePage.qml" line="657"/>
+        <location filename="../homePage/MHomePage.qml" line="724"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="628"/>
+        <location filename="../homePage/MHomePage.qml" line="658"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="656"/>
+        <source>This action will not delete the original books.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="706"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="721"/>
+        <source>Limit Reached</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="722"/>
+        <source>You have reached your upload limit.
+Delete unused books to free up space or upgrade.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="773"/>
+        <source>Ok</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="723"/>
+        <source>Upgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="742"/>
+        <source>Book already exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="743"/>
+        <source>It looks like this book already exists in your library:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="746"/>
+        <source>Are you sure you that want to add it again?
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="749"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="750"/>
+        <source>Don&apos;t add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="771"/>
+        <source>Unsupported File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="772"/>
+        <source>Oops! This file is not supported by Librum.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="797"/>
+        <source>Import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="800"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MHomePage.qml" line="801"/>
+        <location filename="../homePage/MHomePage.qml" line="802"/>
+        <location filename="../homePage/MHomePage.qml" line="803"/>
+        <source>files</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MImageToPdfPopup</name>
+    <message>
+        <location filename="../toolsPage/MImageToPdfPopup.qml" line="39"/>
+        <source>Convertion succeeded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MImageToPdfPopup.qml" line="40"/>
+        <source>The new book was added to your library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MImageToPdfPopup.qml" line="42"/>
+        <source>Convertion failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MImageToPdfPopup.qml" line="43"/>
+        <source>The conversion failed. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MImageToPdfPopup.qml" line="62"/>
+        <location filename="../toolsPage/MImageToPdfPopup.qml" line="148"/>
+        <source>Convert</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MLoginPage</name>
+    <message>
+        <location filename="../loginPage/MLoginPage.qml" line="143"/>
+        <source>Welcome back!</source>
+        <translation>おかえりなさい！</translation>
+    </message>
+    <message>
+        <location filename="../loginPage/MLoginPage.qml" line="153"/>
+        <source>Log into your account</source>
+        <translation>アカウントにログイン</translation>
+    </message>
+    <message>
+        <location filename="../loginPage/MLoginPage.qml" line="164"/>
+        <source>Email</source>
+        <translation>メールアドレス</translation>
+    </message>
+    <message>
+        <location filename="../loginPage/MLoginPage.qml" line="179"/>
+        <source>Password</source>
+        <translation>パスワード</translation>
+    </message>
+    <message>
+        <location filename="../loginPage/MLoginPage.qml" line="225"/>
+        <source>Remember me</source>
+        <translation>ログイン状態を保存</translation>
+    </message>
+    <message>
+        <location filename="../loginPage/MLoginPage.qml" line="246"/>
+        <source>Forgot password?</source>
+        <translation>パスワードをお忘れですか？</translation>
+    </message>
+    <message>
+        <location filename="../loginPage/MLoginPage.qml" line="274"/>
+        <source>Login</source>
+        <translation>ログイン</translation>
+    </message>
+    <message>
+        <location filename="../loginPage/MLoginPage.qml" line="299"/>
+        <source>Don&apos;t have an account? Register</source>
+        <translation>アカウントをお持ちでないですか？ 新規登録</translation>
+    </message>
+    <message>
+        <location filename="../loginPage/MLoginPage.qml" line="320"/>
+        <source>We&apos;re Sorry</source>
+        <translation>申し訳ございません</translation>
+    </message>
+    <message>
+        <location filename="../loginPage/MLoginPage.qml" line="321"/>
+        <source>Logging you in failed, please try again later.</source>
+        <translation>ログインに失敗しました。しばらくしてからもう一度お試しください。</translation>
+    </message>
+    <message>
+        <location filename="../loginPage/MLoginPage.qml" line="322"/>
+        <source>Ok</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../loginPage/MLoginPage.qml" line="323"/>
+        <source>Report</source>
+        <translation>報告</translation>
+    </message>
+</context>
+<context>
+    <name>MManageTagsPopup</name>
+    <message>
+        <location filename="../homePage/manageTagsPopup/MManageTagsPopup.qml" line="31"/>
+        <source>TAGS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/manageTagsPopup/MManageTagsPopup.qml" line="69"/>
+        <source>Manage Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/manageTagsPopup/MManageTagsPopup.qml" line="166"/>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MMergePopup</name>
+    <message>
+        <location filename="../toolsPage/MMergePopup.qml" line="41"/>
+        <source>Merge succeeded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MMergePopup.qml" line="42"/>
+        <source>The merged book was added to your library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MMergePopup.qml" line="44"/>
+        <source>Merge failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MMergePopup.qml" line="45"/>
+        <source>The merged failed. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MMergePopup.qml" line="67"/>
+        <location filename="../toolsPage/MMergePopup.qml" line="223"/>
+        <source>Merge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MMergePopup.qml" line="242"/>
+        <source>Select two or more books to merge.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MMoveToFolderPopup</name>
+    <message>
+        <location filename="../homePage/folderSidebar/MMoveToFolderPopup.qml" line="63"/>
+        <source>Move to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MMoveToFolderPopup.qml" line="328"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MMoveToFolderPopup.qml" line="347"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MNoBookSatisfiesFilterItem</name>
+    <message>
+        <location filename="../homePage/MNoBookSatisfiesFilterItem.qml" line="23"/>
+        <source>No book satisfies the filter conditions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/MNoBookSatisfiesFilterItem.qml" line="37"/>
+        <source>Remove Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MOnOffToggle</name>
+    <message>
+        <location filename="../modules/CustomComponents/MOnOffToggle.qml" line="23"/>
+        <source>OFF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modules/CustomComponents/MOnOffToggle.qml" line="25"/>
+        <source>ON</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MPdfToImagePopup</name>
+    <message>
+        <location filename="../toolsPage/MPdfToImagePopup.qml" line="39"/>
+        <source>Convertion succeeded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MPdfToImagePopup.qml" line="40"/>
+        <source>The new book was added to your library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MPdfToImagePopup.qml" line="42"/>
+        <source>Convertion failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MPdfToImagePopup.qml" line="43"/>
+        <source>The conversion failed. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MPdfToImagePopup.qml" line="62"/>
+        <source>Pdf to Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MPdfToImagePopup.qml" line="148"/>
+        <source>Convert</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MProfilePopup</name>
+    <message>
+        <location filename="../sidebar/MProfilePopup.qml" line="44"/>
+        <source>Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../sidebar/MProfilePopup.qml" line="61"/>
+        <source>Manage Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../sidebar/MProfilePopup.qml" line="77"/>
+        <source>Logout</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MReadingOptionsPopup</name>
+    <message>
+        <location filename="../readingPage/readingToolbar/MReadingOptionsPopup.qml" line="118"/>
+        <source>Invert colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/readingToolbar/MReadingOptionsPopup.qml" line="147"/>
+        <source>Sync book</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/readingToolbar/MReadingOptionsPopup.qml" line="165"/>
+        <source>More options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/readingToolbar/MReadingOptionsPopup.qml" line="186"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MReadingSearchbar</name>
+    <message>
+        <location filename="../readingPage/readingSearchbar/MReadingSearchbar.qml" line="93"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/readingSearchbar/MReadingSearchbar.qml" line="142"/>
+        <source>Find</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/readingSearchbar/MReadingSearchbar.qml" line="169"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/readingSearchbar/MReadingSearchbar.qml" line="188"/>
+        <source>Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MReadingSearchbarOptionsPopup</name>
+    <message>
+        <location filename="../readingPage/readingSearchbar/MReadingSearchbarOptionsPopup.qml" line="52"/>
+        <source>From start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/readingSearchbar/MReadingSearchbarOptionsPopup.qml" line="66"/>
+        <source>Case sensitive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/readingSearchbar/MReadingSearchbarOptionsPopup.qml" line="80"/>
+        <source>Whole words</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MReadingToolBar</name>
+    <message>
+        <location filename="../readingPage/readingToolbar/MReadingToolBar.qml" line="14"/>
+        <source>Unknown name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/readingToolbar/MReadingToolBar.qml" line="188"/>
+        <source>of</source>
+        <extracomment>As in 21 &quot;of&quot; 400</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MRecordKeyBox</name>
+    <message>
+        <location filename="../settings/shortcutsPage/MRecordKeyBox.qml" line="25"/>
+        <source>Key</source>
+        <extracomment>As in key on the keyboard</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/shortcutsPage/MRecordKeyBox.qml" line="105"/>
+        <source>Press to record</source>
+        <extracomment>As in recording a key that is pressed on the keyboard</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MRegisterPage</name>
+    <message>
+        <location filename="../registerPage/MRegisterPage.qml" line="79"/>
+        <source>Welcome!</source>
+        <translation>ようこそ！</translation>
+    </message>
+    <message>
+        <location filename="../registerPage/MRegisterPage.qml" line="90"/>
+        <source>Your credentials are only used to authenticate yourself. Everything will be stored in a secure database.</source>
+        <translation>認証情報は本人確認のためにのみ使用されます。すべてのデータは安全なデータベースに保管されます。</translation>
+    </message>
+    <message>
+        <location filename="../registerPage/MRegisterPage.qml" line="128"/>
+        <source>Email</source>
+        <translation>メールアドレス</translation>
+    </message>
+    <message>
+        <location filename="../registerPage/MRegisterPage.qml" line="142"/>
+        <source>Password</source>
+        <translation>パスワード</translation>
+    </message>
+    <message>
+        <location filename="../registerPage/MRegisterPage.qml" line="115"/>
+        <source>Name</source>
+        <translation>名前</translation>
+    </message>
+    <message>
+        <location filename="../registerPage/MRegisterPage.qml" line="180"/>
+        <source>Let&apos;s start</source>
+        <translation>はじめる</translation>
+    </message>
+    <message>
+        <location filename="../registerPage/MRegisterPage.qml" line="202"/>
+        <source>Already have an account? Login</source>
+        <translation>すでにアカウントをお持ちですか？ ログイン</translation>
+    </message>
+    <message>
+        <location filename="../registerPage/MRegisterPage.qml" line="229"/>
+        <source>Confirm Your Email</source>
+        <translation>メールアドレスの確認</translation>
+    </message>
+    <message>
+        <location filename="../registerPage/MRegisterPage.qml" line="230"/>
+        <source>You&apos;re are almost ready to go!
+Confirm your email by clicking the link we sent you.</source>
+        <translation>準備はもう少しで完了です！
+お送りしたリンクをクリックして、メールアドレスを確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../registerPage/MRegisterPage.qml" line="231"/>
+        <source>Resend</source>
+        <translation>再送信</translation>
+    </message>
+</context>
+<context>
+    <name>MSearchButton</name>
+    <message>
+        <location filename="../modules/CustomComponents/buttons/MSearchButton.qml" line="14"/>
+        <source>Search for books</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MSelectColorPopup</name>
+    <message>
+        <location filename="../homePage/folderSidebar/MSelectColorPopup.qml" line="42"/>
+        <source>Pick a color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MSelectIconPopup</name>
+    <message>
+        <location filename="../homePage/folderSidebar/MSelectIconPopup.qml" line="43"/>
+        <source>Pick an icon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/folderSidebar/MSelectIconPopup.qml" line="101"/>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MSelectProfilePictureArea</name>
+    <message>
+        <location filename="../settings/accountPage/MSelectProfilePictureArea.qml" line="107"/>
+        <source>Click to select an image or drop it into in this area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MSelectProfilePictureArea.qml" line="157"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/accountPage/MSelectProfilePictureArea.qml" line="157"/>
+        <location filename="../settings/accountPage/MSelectProfilePictureArea.qml" line="158"/>
+        <source>files</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MSelectionOptionsPopup</name>
+    <message>
+        <location filename="../readingPage/MSelectionOptionsPopup.qml" line="139"/>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MSelectionOptionsPopup.qml" line="167"/>
+        <source>Look Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MSelectionOptionsPopup.qml" line="207"/>
+        <source>Ai Explain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../readingPage/MSelectionOptionsPopup.qml" line="239"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MSettingsSidebar</name>
+    <message>
+        <location filename="../settings/settingsSidebar/MSettingsSidebar.qml" line="55"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsSidebar/MSettingsSidebar.qml" line="74"/>
+        <source>GLOBAL SETTINGS</source>
+        <extracomment>Keep it capitalized</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsSidebar/MSettingsSidebar.qml" line="90"/>
+        <source>About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsSidebar/MSettingsSidebar.qml" line="106"/>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsSidebar/MSettingsSidebar.qml" line="122"/>
+        <source>Behavior</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsSidebar/MSettingsSidebar.qml" line="139"/>
+        <source>Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsSidebar/MSettingsSidebar.qml" line="155"/>
+        <source>Updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsSidebar/MSettingsSidebar.qml" line="166"/>
+        <source>USER &amp; ACCOUNT</source>
+        <extracomment>Keep it capitalized</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsSidebar/MSettingsSidebar.qml" line="182"/>
+        <source>Account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsSidebar/MSettingsSidebar.qml" line="198"/>
+        <source>Storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsSidebar/MSettingsSidebar.qml" line="215"/>
+        <source>Support us</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MShortcutDelegate</name>
+    <message>
+        <location filename="../settings/shortcutsPage/MShortcutDelegate.qml" line="65"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MShortcutsPage</name>
+    <message>
+        <location filename="../settings/shortcutsPage/MShortcutsPage.qml" line="39"/>
+        <source>Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/shortcutsPage/MShortcutsPage.qml" line="40"/>
+        <source>Make your own experience</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/shortcutsPage/MShortcutsPage.qml" line="57"/>
+        <source>Edit shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/shortcutsPage/MShortcutsPage.qml" line="110"/>
+        <source>ACTION</source>
+        <extracomment>Keep it capitalized</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/shortcutsPage/MShortcutsPage.qml" line="124"/>
+        <source>SHORTCUTS</source>
+        <extracomment>Keep it capitalized</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/shortcutsPage/MShortcutsPage.qml" line="139"/>
+        <source>Search for shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MSidebar</name>
+    <message>
+        <location filename="../sidebar/MSidebar.qml" line="116"/>
+        <source>Free books</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../sidebar/MSidebar.qml" line="138"/>
+        <source>Home</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../sidebar/MSidebar.qml" line="149"/>
+        <source>Statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../sidebar/MSidebar.qml" line="169"/>
+        <source>Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../sidebar/MSidebar.qml" line="180"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MSortByButton</name>
+    <message>
+        <location filename="../homePage/toolbar/sortByButton/MSortByButton.qml" line="46"/>
+        <source>Sort</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MSortByPopup</name>
+    <message>
+        <location filename="../homePage/toolbar/sortByButton/MSortByPopup.qml" line="65"/>
+        <source>Recently added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/sortByButton/MSortByPopup.qml" line="69"/>
+        <source>Recently read</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/sortByButton/MSortByPopup.qml" line="73"/>
+        <source>Progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/sortByButton/MSortByPopup.qml" line="77"/>
+        <source>Book (A-Z)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/sortByButton/MSortByPopup.qml" line="81"/>
+        <source>Authors (A-Z)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MStatisticsPage</name>
+    <message>
+        <location filename="../statisticsPage/MStatisticsPage.qml" line="22"/>
+        <source>Statistics Page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../statisticsPage/MStatisticsPage.qml" line="33"/>
+        <source>Currently in Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MStoragePage</name>
+    <message>
+        <location filename="../settings/MStoragePage.qml" line="42"/>
+        <source>Storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MStoragePage.qml" line="43"/>
+        <source>Your storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MStoragePage.qml" line="59"/>
+        <source>Upgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MStoragePage.qml" line="113"/>
+        <source>YOUR TIER</source>
+        <extracomment>Keep capitalized (&quot;TIER&quot; as in subscription)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MStoragePage.qml" line="147"/>
+        <source>Upgrade Now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MStoragePage.qml" line="179"/>
+        <source>USED STORAGE</source>
+        <extracomment>Keep capitalized</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MStoragePage.qml" line="212"/>
+        <source>Used Storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MStoragePage.qml" line="239"/>
+        <source>Remaining Storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MStoragePage.qml" line="295"/>
+        <source>YOUR BOOKS</source>
+        <extracomment>Keep capitalized</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MStoragePage.qml" line="314"/>
+        <source>Books in your Library</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MSupportUsPage</name>
+    <message>
+        <location filename="../settings/MSupportUsPage.qml" line="33"/>
+        <location filename="../settings/MSupportUsPage.qml" line="95"/>
+        <source>Support us</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MSupportUsPage.qml" line="34"/>
+        <source>Thanks for considering</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MSupportUsPage.qml" line="69"/>
+        <source>We are a small team of opensource developers creating apps for the community. We love
+working on fun projects, supporting our community and trying to make the world a better place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MSupportUsPage.qml" line="79"/>
+        <source>If you feel like supporting us and our projects, feel free to support us:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MSupportUsPage.qml" line="109"/>
+        <source>You can support us in many other ways as well, if you are a developer or a designer, feel free to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MSupportUsPage.qml" line="111"/>
+        <source>contribute to Librum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MSupportUsPage.qml" line="112"/>
+        <source>If you are not, you can still help us by spreading the word about Librum.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/MSupportUsPage.qml" line="147"/>
+        <source>Thank you for your support. We hope you enjoy Librum!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MTagSelectorButton</name>
+    <message>
+        <location filename="../homePage/toolbar/tagSelector/MTagSelectorButton.qml" line="46"/>
+        <source>Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MTagSelectorPopup</name>
+    <message>
+        <location filename="../homePage/toolbar/tagSelector/MTagSelectorPopup.qml" line="119"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/tagSelector/MTagSelectorPopup.qml" line="131"/>
+        <source>Rename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/tagSelector/MTagSelectorPopup.qml" line="140"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MTitle</name>
+    <message>
+        <location filename="../modules/CustomComponents/MTitle.qml" line="9"/>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modules/CustomComponents/MTitle.qml" line="10"/>
+        <source>Description</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MToolbar</name>
+    <message>
+        <location filename="../homePage/toolbar/MToolbar.qml" line="74"/>
+        <source>Remove Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/MToolbar.qml" line="87"/>
+        <source>Remove Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/MToolbar.qml" line="143"/>
+        <source>You are offline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../homePage/toolbar/MToolbar.qml" line="150"/>
+        <source>Your library is being synchronized with the cloud</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MToolsPage</name>
+    <message>
+        <location filename="../toolsPage/MToolsPage.qml" line="25"/>
+        <source>PDF Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MToolsPage.qml" line="26"/>
+        <source>Powerful tools to modify your PDF files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MToolsPage.qml" line="101"/>
+        <source>Merge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MToolsPage.qml" line="102"/>
+        <source>Merge multiple books into one</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MToolsPage.qml" line="107"/>
+        <source>Extract Page(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MToolsPage.qml" line="108"/>
+        <source>Extract selected pages from a book</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MToolsPage.qml" line="113"/>
+        <source>Image to PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../toolsPage/MToolsPage.qml" line="114"/>
+        <source>Convert an image (PNG, JPEG, SVG, GIF) to PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MUpToDate</name>
+    <message>
+        <location filename="../settings/updatesPage/MUpToDate.qml" line="37"/>
+        <source>You are up to date!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/updatesPage/MUpToDate.qml" line="47"/>
+        <source>Make sure to check for updates regularly, so you dont miss out on any great features.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/updatesPage/MUpToDate.qml" line="56"/>
+        <source>Your current version is:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/updatesPage/MUpToDate.qml" line="85"/>
+        <source>See our latest changes at:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MUpdatesAvailable</name>
+    <message>
+        <location filename="../settings/updatesPage/MUpdatesAvailable.qml" line="50"/>
+        <source>A new update is available!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/updatesPage/MUpdatesAvailable.qml" line="60"/>
+        <source>Download the new version to get great new improvements.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/updatesPage/MUpdatesAvailable.qml" line="69"/>
+        <source>The newest version is:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/updatesPage/MUpdatesAvailable.qml" line="95"/>
+        <source>Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/updatesPage/MUpdatesAvailable.qml" line="114"/>
+        <source>See the exact changes on our website at:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/updatesPage/MUpdatesAvailable.qml" line="155"/>
+        <source>Updating on Linux</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/updatesPage/MUpdatesAvailable.qml" line="156"/>
+        <source>Please use your package manager to update Librum or download the newest version from our</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/updatesPage/MUpdatesAvailable.qml" line="158"/>
+        <location filename="../settings/updatesPage/MUpdatesAvailable.qml" line="182"/>
+        <source>website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/updatesPage/MUpdatesAvailable.qml" line="160"/>
+        <location filename="../settings/updatesPage/MUpdatesAvailable.qml" line="184"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/updatesPage/MUpdatesAvailable.qml" line="161"/>
+        <location filename="../settings/updatesPage/MUpdatesAvailable.qml" line="185"/>
+        <source>Email Us</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/updatesPage/MUpdatesAvailable.qml" line="179"/>
+        <source>The Update Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/updatesPage/MUpdatesAvailable.qml" line="180"/>
+        <source>Please try again later or download the newest version from our</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MUpdatesPage</name>
+    <message>
+        <location filename="../settings/updatesPage/MUpdatesPage.qml" line="33"/>
+        <source>Updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/updatesPage/MUpdatesPage.qml" line="34"/>
+        <source>Any new update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MWarningPopup</name>
+    <message>
+        <location filename="../modules/CustomComponents/MWarningPopup.qml" line="11"/>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modules/CustomComponents/MWarningPopup.qml" line="12"/>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modules/CustomComponents/MWarningPopup.qml" line="13"/>
+        <source>Do you Accept?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modules/CustomComponents/MWarningPopup.qml" line="14"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MWindowsUpdatingPopup</name>
+    <message>
+        <location filename="../settings/updatesPage/MWindowsUpdatingPopup.qml" line="60"/>
+        <source>Updating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/updatesPage/MWindowsUpdatingPopup.qml" line="67"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../main.qml" line="37"/>
+        <source>Librum - Your ebook reader</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
## Problem

Closes #221. Japanese is already offered in the language picker (`MLanguageModel.qml` lists 日本語), but `src/presentation/translations/librum_ja.ts` was missing entirely — so selecting Japanese silently fell back to English while 11 other languages shipped.

## Change

Adds `librum_ja.ts` and registers it in `src/presentation/CMakeLists.txt`. This first pass translates the full account / authentication surface — login, register, forgot-password, account settings, and account-deletion (55 strings across 5 contexts). The remaining contexts are left `type="unfinished"`, following the project's existing partial-translation convention (cf. `librum_ko.ts`, which ships with ~101 unfinished).

House style: button labels as nouns (保存 / 削除 / ログアウト), descriptive toggles with 〜する; `Librum` kept in English; embedded HTML entities (`<br>`, `<b>`) and `\n` preserved verbatim.

## Testing

- The `.ts` XML validated as well-formed; structure mirrors the `en` template with filled `<translation>` nodes, LF endings matching siblings.
- Not run through Qt's `lrelease` / a full build — flagging for CI.

